### PR TITLE
add test mode to path patch

### DIFF
--- a/codebook_circuits/mvp/examples/path_patching_demo.py
+++ b/codebook_circuits/mvp/examples/path_patching_demo.py
@@ -1,9 +1,10 @@
 import torch as t
-from codebook_circuits.mvp.codebook_path_patching import slow_single_path_patch
+from codebook_circuits.mvp.codebook_path_patching import single_path_patch
 from codebook_circuits.mvp.data import TravelToCityDataset
 from codebook_circuits.mvp.utils import (
     compute_average_logit_difference,
     setup_pythia410M_hooked_model,
+    time_a_fn,
 )
 
 # Set up model
@@ -26,14 +27,24 @@ original_perfomance = compute_average_logit_difference(
 
 print(f"Original Model Perfomance: {original_perfomance}")
 
+_, orig_cache = cb_model.run_with_cache(orig_input, return_type=None)
+_, new_cache = cb_model.run_with_cache(new_input, return_type=None)
+
 # Path Patch over given sender-receiver path
-path_patched_logits = slow_single_path_patch(
+# Timing Results
+# test_mode = False: 5.33 seconds
+# test mode = True: 10.88 seconds
+
+path_patched_logits, _ = single_path_patch(
     codebook_model=cb_model,
     orig_input=orig_input,
     new_input=new_input,
     sender_name=("cb_5", 17),
     receiver_name=("cb_10", 19),
+    orig_cache=orig_cache,
+    new_cache=new_cache,
     seq_pos=None,
+    test_mode=True,
 )
 
 path_patched_perf = compute_average_logit_difference(

--- a/codebook_circuits/mvp/test_patching.py
+++ b/codebook_circuits/mvp/test_patching.py
@@ -1,5 +1,3 @@
-# TODO: Re-write Tests
-
 from functools import partial
 
 import pytest
@@ -12,7 +10,7 @@ from codebook_circuits.mvp.codebook_path_patching import (
     hook_fn_add_activation_to_ctx,
     hook_fn_generic_patch_or_freeze,
     hook_fn_generic_patching_from_context,
-    slow_single_path_patch,
+    single_path_patch,
 )
 from codebook_circuits.mvp.data import TravelToCityDataset
 from transformer_lens import HookedTransformer
@@ -136,7 +134,7 @@ def test_hook_fn_add_activation_to_ctx(tiny_dataset_and_model):
     )
 
 
-def test_slow_single_path_patch_logits(tiny_dataset_and_model):
+def test_single_path_patch_logits(tiny_dataset_and_model):
     (
         tiny_model,
         orig_tokens,
@@ -149,21 +147,21 @@ def test_slow_single_path_patch_logits(tiny_dataset_and_model):
     sender = ("blocks.1.hook_resid_post",)
     receiver = ("blocks.4.hook_resid_pre",)
     seq_pos = -1
-    patched_logits = slow_single_path_patch(
+    patched_logits, _ = single_path_patch(
         codebook_model=tiny_model,
         orig_input=orig_tokens,
         new_input=new_tokens,
         sender_name=sender,
         receiver_name=receiver,
         seq_pos=seq_pos,
-        test_mode=False,
+        test_mode=True,
     )
 
     assert not t.equal(patched_logits, orig_logits)
     assert not t.equal(patched_logits, new_logits)
 
 
-def test_slow_single_path_patch_cache(tiny_dataset_and_model):
+def test_single_path_patch_cache(tiny_dataset_and_model):
     (
         tiny_model,
         orig_tokens,
@@ -176,7 +174,7 @@ def test_slow_single_path_patch_cache(tiny_dataset_and_model):
     sender = ("blocks.1.hook_resid_post",)
     receiver = ("blocks.4.hook_resid_pre",)
     seq_pos = -1
-    cache = slow_single_path_patch(
+    _, cache = single_path_patch(
         codebook_model=tiny_model,
         orig_input=orig_tokens,
         new_input=new_tokens,

--- a/codebook_circuits/mvp/utils.py
+++ b/codebook_circuits/mvp/utils.py
@@ -1,3 +1,7 @@
+import time
+from functools import wraps
+from typing import Callable
+
 import torch as t
 from codebook_circuits.mvp.data import TravelToCityDataset
 from codebook_features import models
@@ -100,3 +104,15 @@ def setup_pythia410M_hooked_model() -> HookedTransformerCodebookModel:
     cb_model = cb_model.to(device).eval()
 
     return cb_model
+
+
+def time_a_fn(fn: Callable) -> Callable:
+    @wraps(fn)
+    def timed_fn(*args, **kwargs):
+        start = time.time()
+        result = fn(*args, **kwargs)
+        end = time.time()
+        print(f"{fn.__name__} took {end - start} seconds")
+        return result
+
+    return timed_fn


### PR DESCRIPTION
- Add test mode to main path patch function, double runtime when active but checks intermediate activations are as expected. 